### PR TITLE
feat: Show full IP on login prompt

### DIFF
--- a/shellinabox/launcher.c
+++ b/shellinabox/launcher.c
@@ -1007,10 +1007,6 @@ static pam_handle_t *internalLogin(struct Service *service, struct Utmp *utmp,
   const char *fqdn;
   check(fqdn                   = strdup(hostname));
   check(hostname               = strdup(hostname));
-  char *dot                    = strchr(hostname, '.');
-  if (dot) {
-    *dot                       = '\000';
-  }
 
   const struct passwd *pw;
   pam_handle_t *pam            = NULL;

--- a/shellinabox/service.c
+++ b/shellinabox/service.c
@@ -175,8 +175,7 @@ void initService(struct Service *service, const char *arg) {
           "-oHostbasedAuthentication=no -oIdentitiesOnly=yes "
           "-oKbdInteractiveAuthentication=yes -oPasswordAuthentication=yes "
           "-oPreferredAuthentications=keyboard-interactive,password "
-          "-oPubkeyAuthentication=no -oRhostsRSAAuthentication=no "
-          "-oRSAAuthentication=no -oStrictHostKeyChecking=no -oTunnel=no "
+          "-oPubkeyAuthentication=no -oStrictHostKeyChecking=no -oTunnel=no "
           "-oUserKnownHostsFile=/dev/null -oVerifyHostKeyDNS=no "
 // beewoolie-2012.03.30: while it would be nice to disable this
 //          feature, we cannot be sure that it is available on the


### PR DESCRIPTION
To show full IP on the login prompt, and removes deprecated arguments for SSH